### PR TITLE
Add FX rate support and liquidity breakdown

### DIFF
--- a/core/data_client.py
+++ b/core/data_client.py
@@ -93,5 +93,103 @@ class DataClient:
                 prices[stock_symbol] = 100.0
         return prices
 
+    @classmethod
+    def get_exchange_rates(cls, ttl: int = 10) -> Dict[str, float]:
+        """Fetch and normalise exchange rate information.
+
+        The remote endpoint can expose multiple representations of the
+        exchange rate (e.g. MEP, CCL) and the field naming is not entirely
+        consistent.  The method therefore performs a best-effort mapping by
+        looking for well-known column names first and falling back to the
+        first numerical value found on each row.  The resulting dictionary
+        can be used to populate widgets that require one or more reference
+        FX prices.
+        """
+
+        url = cls.BASES.get("MEP")
+        if not url:
+            return {}
+
+        fx_df = cls.fetch(url, ttl=ttl)
+        if fx_df.empty:
+            return {}
+
+        rates: Dict[str, float] = {}
+        lowered_columns = {col.lower(): col for col in fx_df.columns if isinstance(col, str)}
+
+        preferred_columns = [
+            ("MEP", "mep"),
+            ("CCL", "ccl"),
+            ("Blue", "blue"),
+            ("Oficial", "oficial"),
+            ("Promedio", "promedio"),
+        ]
+        for label, column_key in preferred_columns:
+            column_name = lowered_columns.get(column_key)
+            if not column_name:
+                continue
+            series = pd.to_numeric(fx_df[column_name], errors="coerce").dropna()
+            if not series.empty:
+                rates[label] = float(series.mean())
+
+        priority_fields = {
+            "mep",
+            "usd_mep",
+            "usd",
+            "dolar",
+            "dólar",
+            "price",
+            "precio",
+            "close",
+            "last",
+            "c",
+            "value",
+            "venta",
+            "sell",
+            "ask",
+        }
+
+        for idx, row in fx_df.iterrows():
+            symbol = None
+            for candidate in ("symbol", "ticker", "name", "title", "moneda", "instrumento", "tipo"):
+                value = row.get(candidate)
+                if isinstance(value, str) and value.strip():
+                    symbol = value.strip()
+                    break
+            if not symbol:
+                symbol = f"rate_{idx + 1}"
+
+            price: float | None = None
+            for column in row.index:
+                if not isinstance(column, str):
+                    continue
+                if column.lower() not in priority_fields:
+                    continue
+                numeric_value = pd.to_numeric([row[column]], errors="coerce")[0]
+                if pd.notna(numeric_value) and numeric_value > 0:
+                    price = float(numeric_value)
+                    break
+
+            if price is None:
+                numeric_row = pd.to_numeric(row, errors="coerce").dropna()
+                if not numeric_row.empty:
+                    price = float(numeric_row.iloc[0])
+
+            if price is None or price <= 0:
+                continue
+
+            if symbol in rates:
+                rates[symbol] = (rates[symbol] + price) / 2.0
+            else:
+                rates[symbol] = price
+
+        if rates:
+            has_mep_key = any("mep" in key.lower() for key in rates.keys())
+            if not has_mep_key:
+                average_rate = sum(rates.values()) / len(rates)
+                rates.setdefault("MEP", float(average_rate))
+
+        return rates
+
 
 __all__ = ["DataClient"]


### PR DESCRIPTION
## Summary
- add `DataClient.get_exchange_rates` to normalise market FX data
- surface the exchange rate in the dashboard, convert summary prices to USD and add an ARS/USD liquidity breakdown with totals
- show the spot price in USD on the analysis tab and temporarily guard the unfinished strategy block to avoid runtime issues

## Testing
- python -m compileall app.py core

------
https://chatgpt.com/codex/tasks/task_e_68c9babbcc148324ace160b550b86ec1