### PR TITLE
Ensure dashboard works offline and fix ingestion issues

### DIFF
--- a/app.py
+++ b/app.py
@@ -172,8 +172,11 @@ else:
     refresh_interval = 0
 
 with st.sidebar.expander("📊 Parámetros del Modelo"):
-    risk_free_rate = st.number_input("Tasa libre de riesgo (%)", value=5.0, step=0.1) / 100
-    dividend_yield = st.number_input("Rendimiento dividendos (%)", value=0.0, step=0.1) / 100
+    risk_free_rate_input = st.number_input("Tasa libre de riesgo (%)", value=5.0, step=0.1)
+    dividend_yield_input = st.number_input("Rendimiento dividendos (%)", value=0.0, step=0.1)
+
+risk_free_rate = float(risk_free_rate_input) / 100
+dividend_yield = float(dividend_yield_input) / 100
 
 market_open = st.sidebar.time_input("🕘 Apertura mercado", value=datetime.strptime("11:00", "%H:%M").time())
 market_close = st.sidebar.time_input("🕕 Cierre mercado", value=datetime.strptime("17:00", "%H:%M").time())
@@ -193,6 +196,14 @@ if "processed_cache" not in st.session_state or st.session_state["processed_cach
     st.session_state["processed_cache"] = {"key": cache_key, "data": enriched_df.copy()}
 else:
     enriched_df = st.session_state["processed_cache"]["data"].copy()
+
+if enriched_df.empty or "underlying" not in enriched_df.columns:
+    has_underlying_data = False
+else:
+    has_underlying_data = any(
+        not enriched_df[enriched_df["underlying"] == underlying].empty
+        for underlying in DataClient.TARGET_UNDERLYINGS.keys()
+    )
 
 # Sidebar metrics
 st.sidebar.markdown("---")

--- a/core/database.py
+++ b/core/database.py
@@ -131,6 +131,13 @@ class DatabaseManager:
         available = [c for c in columns if c in df.columns]
         records = []
         for _, row in df[available].iterrows():
+            expiration_value = row.get("expiration")
+            if pd.isna(expiration_value):
+                expiration_out = None
+            elif isinstance(expiration_value, pd.Timestamp):
+                expiration_out = expiration_value.to_pydatetime()
+            else:
+                expiration_out = expiration_value
             records.append(
                 (
                     timestamp,
@@ -138,7 +145,7 @@ class DatabaseManager:
                     underlying_symbol,
                     row.get("otype", ""),
                     row.get("K", 0.0),
-                    row.get("expiration"),
+                    expiration_out,
                     row.get("mkt_price", 0.0),
                     row.get("b", 0.0),
                     row.get("a", 0.0),

--- a/core/fallback_data.py
+++ b/core/fallback_data.py
@@ -1,0 +1,73 @@
+"""Fallback datasets used when the remote API is unavailable.
+
+The production application relies on third-party HTTP endpoints that can
+occasionally be unreachable when running locally or in automated tests.
+To keep the experience usable we expose a small curated dataset that can
+be used as a substitute.  The data is intentionally simple but contains
+all the columns required by :class:`~core.processing.OptionsProcessor` so
+that greeks and implied volatility can still be calculated.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+
+def _option_row(
+    option_root: str,
+    underlying: str,
+    strike: float,
+    option_type: str,
+    price: float,
+    bid: float,
+    ask: float,
+    volume: int,
+    open_interest: int,
+    days_to_expiry: int,
+) -> dict[str, object]:
+    expiration = (datetime.utcnow() + timedelta(days=days_to_expiry)).strftime("%Y-%m-%d")
+    suffix = "C" if option_type == "call" else "V"
+    symbol = f"{option_root}{int(strike):03d}{suffix}"
+    return {
+        "symbol": symbol,
+        "underlying": underlying,
+        "strike": strike,
+        "b": bid,
+        "a": ask,
+        "c": price,
+        "v": volume,
+        "oi": open_interest,
+        "expiration": expiration,
+    }
+
+
+_OPTIONS_DATA = [
+    # ALUA (ALU)
+    _option_row("ALU", "ALUA", 320.0, "call", 17.5, 17.0, 18.0, 150, 420, 45),
+    _option_row("ALU", "ALUA", 320.0, "put", 14.0, 13.5, 14.5, 90, 310, 45),
+    _option_row("ALU", "ALUA", 350.0, "call", 9.3, 9.0, 9.6, 120, 275, 75),
+    # GGAL (GFG)
+    _option_row("GFG", "GGAL", 1200.0, "call", 82.0, 81.0, 83.0, 210, 510, 30),
+    _option_row("GFG", "GGAL", 1200.0, "put", 76.5, 75.5, 77.5, 160, 470, 30),
+    _option_row("GFG", "GGAL", 1400.0, "call", 58.0, 57.0, 59.0, 110, 265, 60),
+    # COME (COM)
+    _option_row("COM", "COME", 120.0, "call", 6.2, 6.0, 6.4, 95, 180, 20),
+    _option_row("COM", "COME", 120.0, "put", 5.4, 5.2, 5.6, 70, 150, 20),
+    _option_row("COM", "COME", 140.0, "call", 3.8, 3.6, 4.0, 60, 120, 40),
+]
+
+
+_STOCKS_DATA = [
+    {"symbol": "ALUA", "c": 335.5},
+    {"symbol": "GGAL", "c": 1285.0},
+    {"symbol": "COME", "c": 132.4},
+]
+
+
+FALLBACK_DATASETS = {
+    "https://data912.com/live/arg_options": _OPTIONS_DATA,
+    "https://data912.com/live/arg_stocks": _STOCKS_DATA,
+}
+
+
+__all__ = ["FALLBACK_DATASETS"]


### PR DESCRIPTION
## Summary
- add curated fallback datasets for options and stocks when the remote API is unavailable
- update the data client to use the fallback payloads and add logging for failures
- normalise Streamlit inputs and compute the `has_underlying_data` flag to avoid runtime errors
- convert expiration timestamps before persisting options rows to SQLite

## Testing
- python historical_ingestor.py --interval 0
- python -m compileall core app.py historical_ingestor.py

------
https://chatgpt.com/codex/tasks/task_e_68cad37a14748324bd377cf41b7ca2b7